### PR TITLE
Add sampling factor and exclusion zone for aircraft updates

### DIFF
--- a/mds3loader/config.py
+++ b/mds3loader/config.py
@@ -10,6 +10,18 @@ class Settings(BaseSettings):
     """Application configuration loaded from environment and CLI."""
 
     log_level: str = Field("INFO")
+    sampling_factor: int = Field(1, ge=1, description="Process every Nth update.")
+    exclusion_center_lat: float | None = Field(
+        None, description="Center latitude for the exclusion zone."
+    )
+    exclusion_center_lon: float | None = Field(
+        None, description="Center longitude for the exclusion zone."
+    )
+    exclusion_margin_deg: float = Field(
+        0.0,
+        ge=0.0,
+        description="Half-size in degrees for the exclusion zone bounds.",
+    )
 
     model_config = {
         "env_prefix": "MDS3_",

--- a/mds3loader/utils/aircraft.py
+++ b/mds3loader/utils/aircraft.py
@@ -1,0 +1,58 @@
+"""Utilities for managing aircraft update calculations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from mds3loader.config import Settings
+
+
+@dataclass
+class ExclusionZone:
+    """Square exclusion zone defined around a center point."""
+
+    center_lat: float
+    center_lon: float
+    margin_deg: float
+
+    def contains(self, lat: float, lon: float) -> bool:
+        """Return True if a point lies inside the exclusion zone."""
+
+        return (
+            self.center_lat - self.margin_deg <= lat <= self.center_lat + self.margin_deg
+            and self.center_lon - self.margin_deg
+            <= lon
+            <= self.center_lon + self.margin_deg
+        )
+
+
+def should_run_calculation(
+    lat: float, lon: float, update: int, settings: Settings
+) -> bool:
+    """Return True if an update should trigger a heavy calculation.
+
+    Args:
+        lat: Aircraft latitude.
+        lon: Aircraft longitude.
+        update: Sequential update number (starting from 1).
+        settings: Application configuration.
+
+    The calculation is skipped when the aircraft is inside the exclusion zone
+    or when the sampling factor does not select the current update.
+    """
+
+    if (
+        settings.exclusion_center_lat is not None
+        and settings.exclusion_center_lon is not None
+        and settings.exclusion_margin_deg > 0
+    ):
+        zone = ExclusionZone(
+            settings.exclusion_center_lat,
+            settings.exclusion_center_lon,
+            settings.exclusion_margin_deg,
+        )
+        if zone.contains(lat, lon):
+            return False
+
+    return update % settings.sampling_factor == 0
+

--- a/tests/test_aircraft_filter.py
+++ b/tests/test_aircraft_filter.py
@@ -1,0 +1,25 @@
+"""Tests for aircraft sampling and exclusion logic."""
+
+from mds3loader.config import Settings
+from mds3loader.utils.aircraft import should_run_calculation
+
+
+def test_sampling_factor_skips_updates() -> None:
+    settings = Settings(sampling_factor=3)
+    assert not should_run_calculation(0.0, 0.0, 1, settings)
+    assert not should_run_calculation(0.0, 0.0, 2, settings)
+    assert should_run_calculation(0.0, 0.0, 3, settings)
+
+
+def test_exclusion_zone_prevents_calculation() -> None:
+    settings = Settings(
+        sampling_factor=1,
+        exclusion_center_lat=10.0,
+        exclusion_center_lon=20.0,
+        exclusion_margin_deg=1.0,
+    )
+    # Inside exclusion zone -> skip
+    assert not should_run_calculation(10.5, 20.5, 5, settings)
+    # Outside exclusion zone -> process
+    assert should_run_calculation(12.5, 23.5, 5, settings)
+


### PR DESCRIPTION
## Summary
- make sampling and exclusion zone configurable via Settings
- add helper to skip aircraft updates based on sampling factor and exclusion zone
- test sampling and exclusion logic

## Testing
- `poetry check`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7a7f5993c832fa701364873007d79